### PR TITLE
Fix GitHub Pages asset URLs by adding basePath and assetPrefix

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,8 @@
 const nextConfig = {
   output: 'export',
   trailingSlash: true,
+  basePath: '/ofertify-frontend',
+  assetPrefix: '/ofertify-frontend/',
   images: {
     unoptimized: true
   }


### PR DESCRIPTION
# Fix GitHub Pages Asset URLs for Subdirectory Deployment

## Problem
GitHub Pages deployed from the repository root (`https://euller-regis.github.io/`) was serving the README.md instead of the website. After configuring Pages to use GitHub Actions, assets (JS/CSS) failed to load with 404 errors because Next.js export assumed root-level URLs.

## Solution
Added `basePath: '/ofertify-frontend'` and `assetPrefix: '/ofertify-frontend/'` to [next.config.mjs](cci:7://file:///home/hugo/ofertify-frontend/next.config.mjs:0:0-0:0) to prefix all asset URLs with the repository name, enabling proper loading from `https://euller-regis.github.io/ofertify-frontend/`.

## Changes
- Updated [next.config.mjs](cci:7://file:///home/hugo/ofertify-frontend/next.config.mjs:0:0-0:0) with basePath and assetPrefix configurations.

## Testing
- Merge this PR to main.
- Configure GitHub Pages to deploy from main via GitHub Actions.
- Verify website loads at `https://euller-regis.github.io/ofertify-frontend/` with assets resolving correctly.